### PR TITLE
Fix VBox Guest Additions Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ Requirements
 --------------------------------------------------------------------------------
 1. Install Vagrant <https://www.vagrantup.com/downloads.html>
 
-1. Install VirtualBox <https://www.virtualbox.org/wiki/Downloads>
+1. Install VirtualBox and VirtualBox Extension Pack
+   <https://www.virtualbox.org/wiki/Downloads>.
 
 1. Add `vagrant` and `VBoxManage` to your PATH.
     - This is most likely already done by the installation binaries.
@@ -17,26 +18,11 @@ Requirements
     - You may need to log out and back in for the path modifications to take
       effect.
 
-1. On my Jessie installation I had to apply the following patch before I could
-   successfully shut down and reboot the VM.
-
-        --- /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/plugins/guests/debian8/cap/halt.rb    2015-07-17 13:15:13.000000000 -0700
-        +++ new_halt.rb 2015-11-18 20:11:29.003055639 -0800
-        @@ -4,7 +4,7 @@
-               class Halt
-                 def self.halt(machine)
-                   begin
-        -            machine.communicate.sudo("shutdown -h -H")
-        +            machine.communicate.sudo("systemctl poweroff")
-                   rescue IOError
-                     # Do nothing, because it probably means the machine shut down
-                     # and SSH connection was lost.
-
 Usage
 --------------------------------------------------------------------------------
-1. Check this folder out on your computer somewhere.
+1. Clone this repository onto your computer somewhere.
 
-        svn co https://robotics.mvla.net/svn/frc971/2016/trunk/src/vagrant_dev_vm
+        git clone https://github.com/valkyrierobotics/dev-environment.git
 
 1. Go into the directory and build the VM.
 
@@ -55,10 +41,30 @@ Usage
 1. You can then log in and open a terminal. The username and password are both
    `user`.
 
-1. Download the code and build it.
+1. At this point, you should be able to see "299 Virtual Environment" in the
+   list of VMs in VirtualBox. Go to the settings of "299 Virtual Environment"
+   to customize options such as increasing video memory or number of CPUs.
 
-        git clone https://USERNAME@robotics.mvla.net/gerrit/971-Robot-Code
-        cd 971-Robot-Code
-        bazel build //y2016/... -- $(cat NO_BUILD_AMD64)
+1. Download the code.
 
-   where USERNAME is the same username you use to log into SVN.
+        git clone https://github.com/valkyrierobotics/mass.git
+        cd mass
+
+1. Install Bazel using the Ubuntu binary installer method
+   <https://docs.bazel.build/versions/master/install.html>.
+   Note that although we are using Debian, the binary installer works.
+
+1. Once connected to the robot's radio through wifi, ssh in to verify
+   authenticity of the connection. Press ENTER for password.
+
+        ssh admin@10.2.99.2
+
+Building and Deploying To Robot
+--------------------------------------------------------------------------------
+1. After making any chances, build the code for the RoboRIO.
+
+        bazel build //y2017/download_stripped --cpu=roborio -- $(cat NO_BUILD_ROBORIO)
+
+1. Deploy code to RoboRIO.
+
+        bazel run //y2017/download_stripped --cpu=roborio -- 10.2.99.2

--- a/setup_code_building.sh
+++ b/setup_code_building.sh
@@ -6,6 +6,7 @@ set -u
 export DEBIAN_FRONTEND=noninteractive
 
 readonly PKGS=(
+  ask-pass
   clang-3.6
   clang-format-3.5
   gfortran

--- a/setup_vbox_guest_additions.sh
+++ b/setup_vbox_guest_additions.sh
@@ -8,8 +8,3 @@ export DEBIAN_FRONTEND=noninteractive
 # Install the kernel sources before the guest additions to guarantee that
 # we can compile the kernel module.
 apt-get install -q -y linux-headers-amd64
-
-# Now we can install the guest additions.
-apt-get install -q -y \
-    virtualbox-guest-dkms \
-    virtualbox-guest-x11


### PR DESCRIPTION
Installing the virtualbox guest additions extension pack inside the VM causes compatibility issues if you have a later version of virtualbox installed on the host OS. The plugin vagrant-vbguest is unable to update the guest additions automatically.

I have reproduced this issue on two computers, on both Ubuntu 14.04 and MacOS Sierra 10.12 with vagrant (1.9.7) and virtualbox (5.1.24). I believe that it is better to have the users install the guest edition on their own, at the same time as they install virtualbox.